### PR TITLE
Use HTTP instead of SSH, Add variables support, Add secret support (keyvault)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,40 @@ simplicity and robustness. This is not a crucial feature to implement, since no 
 repository anyway. How often the repo is checked for change is not so critical, as long as we choose wisely the branch we use to control the microservice.
 Further on, how desirable is the scenario for which an operator can automate a deployment of a change to a Sesam node in production, without her being available
 in the case of needing to rollback? Enough with excuses, this could be implemented.
+
+## Example Sesam System config using version 2.0.0
+```
+{
+  "_id": "extra-node-watcher",
+  "type": "system:microservice",
+  "metadata": {
+    "node": "eidsiva"
+  },
+  "docker": {
+    "environment": {
+      "AUTODEPLOYER_PATH": "systems/watcher.conf.json",
+      "BRANCH": "master",
+      "DEPLOY_TOKEN": "$SECRET(GIT_TOKEN)",
+      "GIT_REPO": "$ENV(GIT_REPO)", 
+      "GIT_USERNAME": "<your-username>",
+      "JWT": "$SECRET(JWT)",
+      "LOG_LEVEL": "DEBUG",
+      "SYNC_ROOT": "/",
+      "VARIABLES_FILE_PATH": "variables/variables-test.json",
+      "VAULT_GIT_TOKEN": "$SECRET(GIT_TOKEN)",
+      "VAULT_MOUNTING_POINT": "$ENV(VAULT_MOUNTING_POINT)",
+      "VAULT_URL": "$ENV(VAULT_URL)"
+    },
+    "image": "sesamcommunity/github-autodeployer:2.0.0",
+    "port": 5000
+  }
+}
+```
+### Notes on version 2.0.0:
+* URL changed from SSH to HTTP to simplify python cloning
+* Variables in the config are verified to exist in the variables file. Will complain if not.
+* Secrets used in the config are verified to exist in Key Vault
+    * Key vault must be version 2 (kv2)
+    * Key vault must support login with git token
+        * Git token used for kv2 must have permissions: read:org & write:org
+* Comparison now happens by loading the JSON inside of the files instead of straight directory comparison.

--- a/service/Vaulter.py
+++ b/service/Vaulter.py
@@ -1,0 +1,42 @@
+from hvac import Client
+from hvac.exceptions import InvalidPath
+
+from sys import exit
+
+
+class Vaulter:
+    def __init__(self, url,  git_token, mount_point):
+        self.client = Client(url=url)
+        self.mount_point = mount_point
+        self.client.auth.github.login(git_token)
+        self.missing_secrets = []
+        if not self.client.is_authenticated():
+            print(f'Cannot authenticate vault {url}. Exiting.')
+            exit(-1)
+
+    def get_secret(self, secret):
+        return_value = None
+        try:
+            response = self.client.secrets.kv.v2.read_secret_version(mount_point=self.mount_point, path=secret)
+            key_value = response['data']['data']
+            for k in key_value:
+                return_value = key_value[k]
+                break
+        except InvalidPath as e:
+            print(f'Could not find {secret} in vault. Invalid path: "{e}"')
+            self.missing_secrets.append(secret)
+        return return_value
+
+    def get_secrets(self, secrets):
+        output = {}
+        for s in secrets:
+            output[s] = self.get_secret(s)
+        return output
+
+    def verify(self):
+        if len(self.missing_secrets) != 0:
+            return False
+        return True
+
+    def get_missing_secrets(self):
+        return self.missing_secrets

--- a/service/github-autodeployer.py
+++ b/service/github-autodeployer.py
@@ -46,6 +46,9 @@ logging.debug("Branch: %s" % branch)
 logging.debug("Sync root: %s" % sync_root)
 logging.debug("Target sesam instance: %s" % sesam_api)
 
+if git_username is None:
+    logging.critical('GIT_USERNAME env-var missing! Exiting.')
+    exit(-1)
 
 ## remove a directory if it exists
 def remove_if_exists(path):
@@ -240,11 +243,7 @@ def check_for_unknown():
 
 if __name__ == '__main__':
     ## we first clone the repo, clean it up, and extract the relevant files to prepare the payload.
-    if git_username is None:
-        logging.critical('GIT_USERNAME env-var missing! Set USE_GIT_REPO_V3 to False or add GIT_USERNAME! Exiting.')
-        exit(-1)
-    else:
-        clone_git_repov3()
+    clone_git_repov3()
     clean_git_repo()
     prepare_payload()
     ## we then download the sesam configuration from the api, unpack it, check it ...

--- a/service/github-autodeployer.py
+++ b/service/github-autodeployer.py
@@ -11,18 +11,24 @@ from git import Repo
 import fnmatch
 import logging
 import datetime
+from json import loads as load_json, dumps as dump_json
+from re import findall as regex_findall
+from Vaulter import Vaulter
 
 __author__ = "Enrico Razzetti"
 
-sesam_api = os.environ.get('SESAM_API_URL', 'http://sesam-node:9042/api') # ex: "https://abcd1234.sesam.cloud/api"
+sesam_api = os.environ.get('SESAM_API_URL', 'http://sesam-node:9042/api')  # ex: "https://abcd1234.sesam.cloud/api"
 jwt = os.environ.get('JWT')
-git_repo = os.environ.get('GIT_REPO') # the project you want to sync from
-branch = os.environ.get('BRANCH', 'master') # the branch of the project you want to use for a sync
-sync_root = os.environ.get('SYNC_ROOT', '/') # the top directory from the github repo you want to use for sync
-deploy_token =  os.environ.get('DEPLOY_TOKEN') # ssh deploy key for this particular project
-autodeployer_config_path = os.environ.get('AUTODEPLOYER_PATH') # path to system config in current node config
+git_repo = os.environ.get('GIT_REPO')  # the project you want to sync from
+branch = os.environ.get('BRANCH', 'master')  # the branch of the project you want to use for a sync
+sync_root = os.environ.get('SYNC_ROOT', '/')  # the top directory from the github repo you want to use for sync
+deploy_token = os.environ.get('DEPLOY_TOKEN')  # ssh deploy key for this particular project
+autodeployer_config_path = os.environ.get('AUTODEPLOYER_PATH')  # path to system config in current node config
 git_username = os.environ.get('GIT_USERNAME', None)  # Needed if using clone_git_repov3
-use_git_repo_v3: bool = os.environ.get('USE_GIT_REPO_V3', 'FALSE').lower() == 'true'
+var_file_path: str = os.environ.get('VARIABLES_FILE_PATH')
+vault_git_token = os.environ.get('VAULT_GIT_TOKEN')
+vault_mounting_point = os.environ.get('VAULT_MOUNTING_POINT')
+vault_url = os.environ.get('VAULT_URL')
 ## internal, skeleton, don't touch, you perv! *touchy, touchy*
 
 git_cloned_dir = "/tmp/git_upstream_clone"
@@ -48,23 +54,17 @@ def remove_if_exists(path):
             # os.remove(path)
             shutil.rmtree(path)
 
-## clone a github repo version2: using python libraries
-def clone_git_repov2():
-    ssh_cmd = 'ssh -o "StrictHostKeyChecking=no" -i id_deployment_key'
-    remove_if_exists(git_cloned_dir)
-    logging.info('cloning %s', git_repo)
-    Repo.clone_from(git_repo, git_cloned_dir, env=dict(GIT_SSH_COMMAND=ssh_cmd),branch=branch)
-
 
 def clone_git_repov3():
-    url = f'https://{git_username}:{deploy_token}@{git_repo.split("@")[-1]}'
+    remove_if_exists(git_cloned_dir)
+    url = f'https://{git_username}:{deploy_token}@{git_repo.split("@")[-1].replace(":", "/")}'
     repo = Repo.clone_from(url, git_cloned_dir, branch=branch)
     return repo
 
 
 ## remove .git, .gitignore and README from a cloned github repo directory
 def clean_git_repo():
-    #os.chdir(git_cloned_dir)
+    # os.chdir(git_cloned_dir)
     for path in glob.glob(git_cloned_dir + "/" + '.git'):
         shutil.rmtree(path)
     for path in glob.glob(git_cloned_dir + "/" + '.gitignore'):
@@ -87,15 +87,68 @@ def zip_payload():
                 logging.debug(file)
                 zippit.write(file)
 
+
 ## create a directory
 def create_dir(path):
     if not os.path.exists(path):
         os.makedirs(path)
 
 
-def extract_sesam_files_with_whitelist(whitelist_path='node/deployment/whitelist-test.txt'):
-    pass
+def do_put(ses, url, json, params=None):
+    retries = 4
+    try:
+        for tries in range(retries):
+            request = ses.put(url=url, json=json, params=params)
+            if request.ok:
+                logging.info(f'Succesfully PUT request to "{url}"')
+                return 0
+            else:
+                logging.warning(
+                    f'Could not PUT request to url "{url}". Got response {request.content}. Current try {tries} of {retries}')
+        logging.error(f'Each PUT request failed to "{url}".')
+        return -1
+    except Exception as e:
+        logging.error(f'Got exception "{e}" while doing PUT request to url "{url}"')
+        return -2
 
+
+def verify_node(node):
+    node_string = dump_json(node)
+
+    variables_in_conf = regex_findall(r'\$ENV\((\S*?)\)', node_string)  # Find env vars
+    variables: dict = load_json(open(git_cloned_dir + sync_root + 'node/' + var_file_path).read())
+    for var in variables_in_conf:  # Verify they exist in git repo
+        if var not in variables:
+            logging.error(f'Missing env var {var} in variables file {var_file_path}')
+
+    secrets_in_conf = regex_findall(r'\$SECRET\((\S*?)\)', node_string)  # Find secrets
+    vault = Vaulter(vault_url, vault_git_token, vault_mounting_point)  # Create keyvault object
+    secrets: dict = vault.get_secrets(secrets_in_conf)  # Get the secrets from keyvault
+    if vault.verify() is False:  # Verify all secrets exist.
+        logging.error(f'These secrets do not exist in the vault {vault.get_missing_secrets()}')
+    return variables, secrets
+
+
+def load_sesam_files_as_json(dir):
+    node_config = []
+    for name in os.listdir(dir):
+        path = os.path.join(dir, name)
+        if os.path.isfile(path) and fnmatch.fnmatch(name, 'node-metadata.conf.json'):
+            node_config.append(load_json(open(path).read()))
+        elif os.path.isdir(path):
+            if fnmatch.fnmatch(name, 'pipes') or fnmatch.fnmatch(name, 'systems'):
+                pipes_or_systems = os.listdir(path)
+                for p_s in pipes_or_systems:
+                    local_path = os.path.join(path, p_s)
+                    node_config.append(load_json(open(local_path).read()))
+    return node_config
+
+
+def compare_json_dict_list(list1, list2):
+    sorted1 = sorted(list1, key=lambda i: i['_id'])
+
+    sorted2 = sorted(list2, key=lambda i: i['_id'])
+    return sorted1 == sorted2
 
 
 ## match the sesam configuration files and copy them to the payload directory
@@ -153,15 +206,17 @@ def upload_payload():
 ## unzip the downloaded sesam zip archive
 def unpack_sesam_zip():
     remove_if_exists(sesam_checkout_dir + "/" + "unpacked")
-    create_dir(sesam_checkout_dir  + "/" + "unpacked")
+    create_dir(sesam_checkout_dir + "/" + "unpacked")
     zip_ref = zipfile.ZipFile(sesam_checkout_dir + "/" + "sesam.zip", 'r')
     zip_ref.extractall(sesam_checkout_dir + "/" + "unpacked")
     zip_ref.close()
+
 
 def copy_autodeployer():
     start_path = sesam_checkout_dir + "/" + "unpacked/" + autodeployer_config_path
     target_path = payload_dir + "/" + autodeployer_config_path
     shutil.copyfile(start_path, target_path)
+
 
 ## check that there is no error in the downloaded zip.
 ## we observed that if the downloaded archive from archive
@@ -175,48 +230,21 @@ def check_for_unknown():
         logging.warning("WARNING:")
         logging.warning("Looks like Sesam has flagged some of your github committed data as gibberish:")
         logging.warning("I detected a directory called 'unknown' in the dowloaded configuration from the node.")
-        logging.warning("This could be, for example, some data file added to the pipes directory. But i don't know for sure.")
-        logging.warning("This error is in your github committed code and should be corrected before continuing with your workflow,")
+        logging.warning(
+            "This could be, for example, some data file added to the pipes directory. But i don't know for sure.")
+        logging.warning(
+            "This error is in your github committed code and should be corrected before continuing with your workflow,")
         logging.warning("else, prepare for unexpected behaviour. Hic Sunt Leones. You have been warned.")
         logging.warning("\n")
 
 
-## compare the content of two directories and the content of the files
-def compare_directories(dir1, dir2):
-    dirs_cmp = filecmp.dircmp(dir1, dir2)
-    if len(dirs_cmp.left_only) > 0 or len(dirs_cmp.right_only) > 0 or \
-            len(dirs_cmp.funny_files) > 0:
-        logging.info("These are new files from Github : %s" % dirs_cmp.right_only )
-        logging.info("These files will be gone from Sesam : %s" % dirs_cmp.left_only )
-        return False
-    (_, mismatch, errors) = filecmp.cmpfiles(
-        dir1, dir2, dirs_cmp.common_files, shallow=False)
-    if len(mismatch) > 0 or len(errors) > 0:
-        logging.info("These files changed : %s" % dirs_cmp.diff_files )
-        return False
-    for common_dir in dirs_cmp.common_dirs:
-        new_dir1 = os.path.join(dir1, common_dir)
-        new_dir2 = os.path.join(dir2, common_dir)
-        if not compare_directories(new_dir1, new_dir2):
-            return False
-    return True
-
-
 if __name__ == '__main__':
-    os.chdir("/service")
-    with open("id_deployment_key", "w") as key_file:
-        key_file.write(os.environ['DEPLOY_TOKEN'])
-    os.chmod("id_deployment_key", 0o600)
-
     ## we first clone the repo, clean it up, and extract the relevant files to prepare the payload.
-    if use_git_repo_v3:
-        if git_username is None:
-            logging.critical('GIT_USERNAME env-var missing! Set USE_GIT_REPO_V3 to False or add GIT_USERNAME! Exiting.')
-            exit(-1)
-        else:
-            clone_git_repov3()
+    if git_username is None:
+        logging.critical('GIT_USERNAME env-var missing! Set USE_GIT_REPO_V3 to False or add GIT_USERNAME! Exiting.')
+        exit(-1)
     else:
-        clone_git_repov2()
+        clone_git_repov3()
     clean_git_repo()
     prepare_payload()
     ## we then download the sesam configuration from the api, unpack it, check it ...
@@ -224,10 +252,21 @@ if __name__ == '__main__':
     unpack_sesam_zip()
     check_for_unknown()
     copy_autodeployer()
-    ## ... then we compare the two directories, and if there are differences, we pack the payload
-    ## and push it back to the api. This overwrites the existing configuration.
-    if not compare_directories(sesam_checkout_dir + "/" + "unpacked", payload_dir):
-        logging.info("Uploading new configuration from github to your Sesam node api.")
+
+    new_node = load_sesam_files_as_json(git_cloned_dir + "/" + sync_root + '/node')
+    old_node = load_sesam_files_as_json(sesam_checkout_dir + "/" + "unpacked")
+    if not compare_json_dict_list(old_node, new_node):
+        # Verify variables & secrets
+        variables, secrets = verify_node(new_node)
+
+        logging.debug(f'Uploading secrets & variables to node!')
+        # Upload variables & secrets
+        session = requests.session()
+        session.headers = {'Authorization': f'bearer {jwt}'}
+        if do_put(session, f'{sesam_api}/secrets', json=secrets) != 0 or do_put(session, f'{sesam_api}/env', json=variables) != 0:
+            logging.error('Failed to upload secrets or variables to node!')
+            exit(-1)
+        logging.info(f"Uploading new configuration from github to node {sesam_api}")
         zip_payload()
         upload_payload()
     else:

--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -1,3 +1,3 @@
 requests==2.20.0
-PyGithub==1.35
-GitPython==2.1.8
+gcg==0.2.0
+hvac==0.9.6


### PR DESCRIPTION
This PR will mess up every instance of this microservice running "latest" tag. 
Should this be it's own repository?

- * URL changed from SSH to HTTP to simplify python cloning
- * Variables in the config are verified to exist in the variables file. Will complain if not.
- * Secrets used in the config are verified to exist in Key Vault
-     * Key vault must be version 2 (kv2)
-     * Key vault must support login with git token
-         * Git token used for kv2 must have permissions: read:org & write:org
- * Comparison now happens by loading the JSON inside of the files instead of straight directory comparison.