### PR TITLE
Set encoding when opening json containing env variables

### DIFF
--- a/service/github-autodeployer.py
+++ b/service/github-autodeployer.py
@@ -173,7 +173,7 @@ def verify_node(node):
     secrets = None
     if upload_variables:
         variables_in_conf = regex_findall(r'\$ENV\((\S*?)\)', node_string)  # Find env vars
-        variables: dict = load_json(open(git_cloned_dir + var_file_path).read())
+        variables: dict = load_json(open(git_cloned_dir + var_file_path, encoding='utf-8-sig').read())
         for var in variables_in_conf:  # Verify they exist in git repo
             if var not in variables:
                 logging.error(f'Missing env var {var} in variables file {var_file_path}')


### PR DESCRIPTION
The autodeployer crashes with the error 
`json.decoder.JSONDecodeError: Unexpected UTF-8 BOM (decode using utf-8-sig): line 1 column 1 (char 0)`
when trying to decode the json containing environment variables for the node. Setting the `encoding` option should fix this.